### PR TITLE
Sanitize stored blog post HTML before rendering

### DIFF
--- a/backend/src/main/java/com/zavan/dedesite/model/Post.java
+++ b/backend/src/main/java/com/zavan/dedesite/model/Post.java
@@ -50,6 +50,10 @@ public class Post {
 
     public void setContent(String content) { this.content_md = content; }
 
+    public String getContentHtml() { return content_html; }
+
+    public void setContentHtml(String contentHtml) { this.content_html = contentHtml; }
+
     public LocalDateTime getCreatedAt() { return createdAt; }
 
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }

--- a/backend/src/main/java/com/zavan/dedesite/service/PostService.java
+++ b/backend/src/main/java/com/zavan/dedesite/service/PostService.java
@@ -17,12 +17,17 @@ public class PostService {
     @Autowired
     private PostRepository postRepository;
 
+    @Autowired
+    private MarkdownService markdownService;
+
     public List<Post> getAllPosts() {
         return postRepository.findAllByOrderByCreatedAtDesc();
     }
     
     public void savePost(Post post) {
-    postRepository.save(post);
+        String safeHtml = markdownService.toSafeHtml(post.getContent());
+        post.setContentHtml(safeHtml);
+        postRepository.save(post);
     }
     
     public Page<Post> getPostsPaginated(int page, int size) {

--- a/backend/src/main/resources/templates/blog.html
+++ b/backend/src/main/resources/templates/blog.html
@@ -31,7 +31,7 @@
             <article>
                 <p><i th:text="${#temporals.format(post.createdAt, 'dd/MM/yyyy HH:mm')}">Data</i></p>
                 <h2 th:text="${post.title}">Título</h2>
-                <div th:utext="${post.content}">Conteúdo</div>
+                <div th:utext="${post.contentHtml}">Conteúdo</div>
                 <div th:if="${#authorization.expression('hasRole(''ADMIN'')')}">
                     <form th:action="@{'/blog/delete/' + ${post.id}}" method="post" style="display: inline;">
                         <button type="submit" onclick="return confirm('Tem certeza que deseja apagar esta postagem?')"> Apagar</button>


### PR DESCRIPTION
## Summary
- sanitize markdown posts through the MarkdownService before persisting
- store both markdown and sanitized HTML variants on the Post entity
- render the pre-sanitized HTML in the blog template

## Testing
- mvn test *(fails: release version 24 not supported by compiler)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bae8a4548332b63252105dd658ba