### PR TITLE
Add CSRF tokens to Thymeleaf forms

### DIFF
--- a/backend/src/main/resources/templates/blog.html
+++ b/backend/src/main/resources/templates/blog.html
@@ -34,6 +34,7 @@
                 <div th:utext="${post.content}">Conteúdo</div>
                 <div th:if="${#authorization.expression('hasRole(''ADMIN'')')}">
                     <form th:action="@{'/blog/delete/' + ${post.id}}" method="post" style="display: inline;">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                         <button type="submit" onclick="return confirm('Tem certeza que deseja apagar esta postagem?')"> Apagar</button>
                     </form>
                 </div>

--- a/backend/src/main/resources/templates/login.html
+++ b/backend/src/main/resources/templates/login.html
@@ -10,6 +10,7 @@
 
 <!--Thymeleaf -->
 <form th:action="@{/login}" method="post">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
     <label for="username">Usuário:</label>
     <input type="text" name="username" id="username" required><br/>
 

--- a/backend/src/main/resources/templates/new_post.html
+++ b/backend/src/main/resources/templates/new_post.html
@@ -16,6 +16,7 @@
     <h1>Nova Postagem</h1>
     
     <form id="postForm" th:action="@{/blog}" th:object="${postDto}" method="post" onsubmit="beforeSubmit()">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <div>
             <label for="title">Título:</label><br>
             <input id="title" th:field="*{title}" style="width:100%;max-width:800px" maxlength="255" required>

--- a/backend/src/main/resources/templates/register.html
+++ b/backend/src/main/resources/templates/register.html
@@ -7,6 +7,7 @@
 <h2>Cadastro</h2>
 
 <form th:action="@{/register}" th:object="${user}" method="post">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
     <label>Usuário:</label>
     <input type="text" th:field="*{username}" /><br/>
 


### PR DESCRIPTION
## Summary
- add the CSRF hidden token field to the login, register, and new post forms
- include the CSRF token in the blog delete form to keep POST deletions valid

## Testing
- mvn -q test *(fails: release version 24 not supported in compiler)*

------
https://chatgpt.com/codex/tasks/task_e_68d5baea03d08332a5b1cbbed7271748