### PR TITLE
Refine security configuration for public pages

### DIFF
--- a/backend/src/main/java/com/zavan/dedesite/config/SecurityConfig.java
+++ b/backend/src/main/java/com/zavan/dedesite/config/SecurityConfig.java
@@ -20,16 +20,6 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-            .authorizeHttpRequests(auth -> auth
-                // arquivos públicos (imagens)
-                .requestMatchers(HttpMethod.GET, "/uploads/**").permitAll()
-                // estáticos comuns (se tiver)
-                .requestMatchers("/css/**", "/js/**", "/images/**").permitAll()
-                // upload restrito (mas também há @PreAuthorize no controller)
-                .requestMatchers("/api/uploads/**").hasAnyRole("ADMIN", "AUTHOR")
-                // demais rotas do site (ajuste conforme seu fluxo)
-                .anyRequest().permitAll()
-            )
             .formLogin(form -> form
                 .loginPage("/login")
                 .defaultSuccessUrl("/", true)
@@ -52,11 +42,16 @@ public class SecurityConfig {
               .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
             )
             .authorizeHttpRequests(auth -> auth
-              .requestMatchers("/", "/login", "/register", "/css/**", "/images/**", "/js/**", "/uploads/**").permitAll()
-              .anyRequest().authenticated()
-            )
-            .formLogin(Customizer.withDefaults())
-            .logout(Customizer.withDefaults());
+                // arquivos públicos (imagens)
+                .requestMatchers(HttpMethod.GET, "/uploads/**").permitAll()
+                // páginas públicas
+                .requestMatchers("/", "/blog", "/blog/**", "/login", "/register").permitAll()
+                // estáticos comuns (se tiver)
+                .requestMatchers("/css/**", "/js/**", "/images/**").permitAll()
+                // upload restrito (mas também há @PreAuthorize no controller)
+                .requestMatchers("/api/uploads/**").hasAnyRole("ADMIN", "AUTHOR")
+                .anyRequest().authenticated()
+            );
         return http.build();
     }
     


### PR DESCRIPTION
## Summary
- consolidate the security matcher rules into a single authorizeHttpRequests block while explicitly permitting public blog routes
- keep the custom login and logout configuration active and continue restricting upload APIs to ADMIN/AUTHOR roles

## Testing
- `./mvnw test` *(fails: release version 24 not supported in container JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68d5be3749b483329db3f2e350c0b325